### PR TITLE
Fix naming conflicts

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.h
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.h
@@ -19,19 +19,6 @@
 #pragma mark - definitions
 
 /**
- * HTTP Request methods
- */
-extern NSString* const kHTTPMethodGET;
-extern NSString* const kHTTPMethodPOST;
-
-/**
- * Content-type strings
- */
-extern NSString* const kContentTypeAutomatic;
-extern NSString* const kContentTypeJSON;
-extern NSString* const kContentTypeWWWEncoded;
-
-/**
  * A block type to handle incoming JSON object and an error. 
  * You pass it to methods which fetch JSON asynchronously. When the operation is finished
  * you receive back the fetched JSON (or nil) and an error (or nil)

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.m
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.m
@@ -19,12 +19,12 @@
 typedef void (^RequestResultBlock)(NSData *data, JSONModelError *error);
 
 #pragma mark - constants
-NSString* const kHTTPMethodGET = @"GET";
-NSString* const kHTTPMethodPOST = @"POST";
+static NSString* const kHTTPMethodGET = @"GET";
+static NSString* const kHTTPMethodPOST = @"POST";
 
-NSString* const kContentTypeAutomatic    = @"jsonmodel/automatic";
-NSString* const kContentTypeJSON         = @"application/json";
-NSString* const kContentTypeWWWEncoded   = @"application/x-www-form-urlencoded";
+static NSString* const kContentTypeAutomatic    = @"jsonmodel/automatic";
+static NSString* const kContentTypeJSON         = @"application/json";
+static NSString* const kContentTypeWWWEncoded   = @"application/x-www-form-urlencoded";
 
 #pragma mark - static variables
 


### PR DESCRIPTION
This PR addresses an issue where certain symbols were conflicting with identically named symbols in another library used by MobilityWare apps.